### PR TITLE
feat: CyberArk access policies — superseded by feat/cyberark-sca-policies-v2

### DIFF
--- a/modules/aws-iam-policies/main.tf
+++ b/modules/aws-iam-policies/main.tf
@@ -1,20 +1,15 @@
 # AWS IAM Policies Module
 #
-# This module creates standardized IAM policies and roles for newly provisioned
-# AWS accounts based on environment and team requirements.
+# Creates three cross-account IAM roles in the management account that map to
+# CyberArk Identity access tiers for a provisioned AWS account.
 #
-# TODO: Implement IAM policy creation logic
-# - Create baseline IAM roles (admin, developer, read-only)
-# - Define least-privilege IAM policies
-# - Configure cross-account access roles
-# - Set up service control policies (SCPs) if applicable
-# - Create policies for common services (S3, EC2, RDS, etc.)
-# - Implement ABAC (Attribute-Based Access Control) patterns
-# - Configure IAM password policy
-# - Set up MFA requirements
+# Role mapping:
+#   RequesterPowerUser  → PowerUserAccess managed policy
+#   AuditorReadOnly     → ReadOnlyAccess + SecurityAudit managed policies
+#   CloudOpsAdmin       → AdministratorAccess managed policy
 
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     aws = {
@@ -24,4 +19,99 @@ terraform {
   }
 }
 
-# Placeholder for IAM policy implementation
+locals {
+  role_prefix = "lab-${var.account_name}-${var.environment}"
+}
+
+# ── Trust policy ─────────────────────────────────────────────────────────────
+# Allows principals from the management account to assume these roles.
+# In production this would be scoped to a CyberArk SAML identity provider.
+
+data "aws_iam_policy_document" "cross_account_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.management_account_id}:root"]
+    }
+
+    dynamic "condition" {
+      for_each = var.require_mfa ? [1] : []
+      content {
+        test     = "Bool"
+        variable = "aws:MultiFactorAuthPresent"
+        values   = ["true"]
+      }
+    }
+  }
+}
+
+# ── Power User role ───────────────────────────────────────────────────────────
+
+resource "aws_iam_role" "power_user" {
+  name               = "${local.role_prefix}-RequesterPowerUser"
+  description        = "Power user access for ${var.account_name} — requester tier"
+  assume_role_policy = data.aws_iam_policy_document.cross_account_trust.json
+
+  tags = {
+    AccountName = var.account_name
+    Environment = var.environment
+    OwnerTeam   = var.owner_team
+    AccessTier  = "PowerUser"
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "power_user" {
+  role       = aws_iam_role.power_user.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+# ── Audit (Read-Only) role ────────────────────────────────────────────────────
+
+resource "aws_iam_role" "auditor" {
+  name               = "${local.role_prefix}-AuditorReadOnly"
+  description        = "Read-only audit access for ${var.account_name} — auditor tier"
+  assume_role_policy = data.aws_iam_policy_document.cross_account_trust.json
+
+  tags = {
+    AccountName = var.account_name
+    Environment = var.environment
+    OwnerTeam   = var.owner_team
+    AccessTier  = "AuditReadOnly"
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "auditor_readonly" {
+  role       = aws_iam_role.auditor.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "auditor_security_audit" {
+  role       = aws_iam_role.auditor.name
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+# ── Cloud Ops Admin role ──────────────────────────────────────────────────────
+
+resource "aws_iam_role" "cloudops_admin" {
+  name               = "${local.role_prefix}-CloudOpsAdmin"
+  description        = "Admin access for ${var.account_name} — cloud-ops team"
+  assume_role_policy = data.aws_iam_policy_document.cross_account_trust.json
+
+  tags = {
+    AccountName = var.account_name
+    Environment = var.environment
+    OwnerTeam   = var.owner_team
+    AccessTier  = "CloudOpsAdmin"
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "cloudops_admin" {
+  role       = aws_iam_role.cloudops_admin.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/modules/aws-iam-policies/outputs.tf
+++ b/modules/aws-iam-policies/outputs.tf
@@ -1,26 +1,29 @@
-# AWS IAM Policies Outputs
-
-output "admin_role_arn" {
-  description = "ARN of the administrator role"
-  value       = "" # Placeholder
+output "power_user_role_arn" {
+  description = "ARN of the RequesterPowerUser cross-account role"
+  value       = aws_iam_role.power_user.arn
 }
 
-output "developer_role_arn" {
-  description = "ARN of the developer role"
-  value       = "" # Placeholder
+output "auditor_role_arn" {
+  description = "ARN of the AuditorReadOnly cross-account role"
+  value       = aws_iam_role.auditor.arn
 }
 
-output "readonly_role_arn" {
-  description = "ARN of the read-only role"
-  value       = "" # Placeholder
+output "cloudops_admin_role_arn" {
+  description = "ARN of the CloudOpsAdmin cross-account role"
+  value       = aws_iam_role.cloudops_admin.arn
 }
 
-output "policy_arns" {
-  description = "Map of created policy names to their ARNs"
-  value       = {} # Placeholder
+output "power_user_role_name" {
+  description = "Name of the RequesterPowerUser role"
+  value       = aws_iam_role.power_user.name
 }
 
-output "custom_policy_arns" {
-  description = "ARNs of custom policies created"
-  value       = {} # Placeholder
+output "auditor_role_name" {
+  description = "Name of the AuditorReadOnly role"
+  value       = aws_iam_role.auditor.name
+}
+
+output "cloudops_admin_role_name" {
+  description = "Name of the CloudOpsAdmin role"
+  value       = aws_iam_role.cloudops_admin.name
 }

--- a/modules/aws-iam-policies/variables.tf
+++ b/modules/aws-iam-policies/variables.tf
@@ -1,12 +1,15 @@
-# AWS IAM Policies Variables
-
 variable "account_id" {
-  description = "AWS account ID where policies will be created"
+  description = "AWS account ID of the provisioned account"
+  type        = string
+}
+
+variable "account_name" {
+  description = "Name/label of the provisioned AWS account (used in role names)"
   type        = string
 }
 
 variable "environment" {
-  description = "Environment type (dev, staging, prod)"
+  description = "Environment tier (dev, staging, prod)"
   type        = string
 
   validation {
@@ -16,45 +19,17 @@ variable "environment" {
 }
 
 variable "owner_team" {
-  description = "Team that owns this account"
+  description = "Team responsible for this account"
   type        = string
 }
 
-variable "create_admin_role" {
-  description = "Create an administrator role"
-  type        = bool
-  default     = true
-}
-
-variable "create_developer_role" {
-  description = "Create a developer role with limited permissions"
-  type        = bool
-  default     = true
-}
-
-variable "create_readonly_role" {
-  description = "Create a read-only role"
-  type        = bool
-  default     = true
-}
-
-variable "trusted_principals" {
-  description = "List of AWS principals that can assume the created roles"
-  type        = list(string)
-  default     = []
+variable "management_account_id" {
+  description = "AWS management account ID — used as the trusted principal in cross-account role trust policies"
+  type        = string
 }
 
 variable "require_mfa" {
-  description = "Require MFA for role assumption"
+  description = "Require MFA when assuming these roles (recommended for prod)"
   type        = bool
-  default     = true
-}
-
-variable "custom_policies" {
-  description = "Map of custom IAM policies to create"
-  type = map(object({
-    description = string
-    policy_json = string
-  }))
-  default = {}
+  default     = false
 }

--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -1,0 +1,65 @@
+# CyberArk Identity — Access Policy Module
+#
+# Creates one CyberArk Identity role per access tier for a provisioned AWS account.
+# All access is defined as code alongside the infrastructure it governs — changes
+# flow through version control and the same approval gate as account creation.
+#
+# Role naming convention: aws-{account_name}-{tier}
+#   poweruser      → RequesterPowerUser  (PowerUserAccess in AWS)
+#   audit          → AuditorReadOnly     (ReadOnlyAccess + SecurityAudit in AWS)
+#   cloudopsadmin  → CloudOpsAdmin       (AdministratorAccess in AWS)
+#
+# TODO: Replace idsec_role / idsec_role_member with Secure Cloud Access (SCA)
+#       policy resources once the correct resource types are confirmed.
+
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    idsec = {
+      source  = "cyberark/idsec"
+      version = "~> 1.0"
+    }
+  }
+}
+
+# ── CyberArk Identity Roles ───────────────────────────────────────────────────
+
+resource "idsec_role" "power_user" {
+  name        = "aws-${var.account_name}-poweruser"
+  description = "Power user access to AWS account ${var.account_name} (${var.account_id}) — ${var.environment}"
+}
+
+resource "idsec_role" "audit" {
+  name        = "aws-${var.account_name}-audit"
+  description = "Read-only audit access to AWS account ${var.account_name} (${var.account_id})"
+}
+
+resource "idsec_role" "cloudops_admin" {
+  name        = "aws-${var.account_name}-cloudopsadmin"
+  description = "Admin access to AWS account ${var.account_name} (${var.account_id}) — cloud-ops team"
+}
+
+# ── Role Membership ───────────────────────────────────────────────────────────
+
+resource "idsec_role_member" "requester_power_user" {
+  role_id     = idsec_role.power_user.id
+  member_name = var.requester_username
+  member_type = "User"
+}
+
+resource "idsec_role_member" "auditor_group" {
+  count = var.auditor_group != "" ? 1 : 0
+
+  role_id     = idsec_role.audit.id
+  member_name = var.auditor_group
+  member_type = "Group"
+}
+
+resource "idsec_role_member" "cloudops_group" {
+  count = var.cloudops_group != "" ? 1 : 0
+
+  role_id     = idsec_role.cloudops_admin.id
+  member_name = var.cloudops_group
+  member_type = "Group"
+}

--- a/modules/cyberark-policy/outputs.tf
+++ b/modules/cyberark-policy/outputs.tf
@@ -1,0 +1,29 @@
+output "power_user_role_id" {
+  description = "CyberArk Identity role ID for the Power User tier"
+  value       = idsec_role.power_user.id
+}
+
+output "audit_role_id" {
+  description = "CyberArk Identity role ID for the Audit (Read-Only) tier"
+  value       = idsec_role.audit.id
+}
+
+output "cloudops_admin_role_id" {
+  description = "CyberArk Identity role ID for the Cloud Ops Admin tier"
+  value       = idsec_role.cloudops_admin.id
+}
+
+output "power_user_role_name" {
+  description = "CyberArk Identity role name for the Power User tier"
+  value       = idsec_role.power_user.name
+}
+
+output "audit_role_name" {
+  description = "CyberArk Identity role name for the Audit tier"
+  value       = idsec_role.audit.name
+}
+
+output "cloudops_admin_role_name" {
+  description = "CyberArk Identity role name for the Cloud Ops Admin tier"
+  value       = idsec_role.cloudops_admin.name
+}

--- a/modules/cyberark-policy/variables.tf
+++ b/modules/cyberark-policy/variables.tf
@@ -1,0 +1,31 @@
+variable "account_id" {
+  description = "AWS account ID of the provisioned account"
+  type        = string
+}
+
+variable "account_name" {
+  description = "Name/label of the provisioned AWS account (used in role names)"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment tier (dev, staging, prod)"
+  type        = string
+}
+
+variable "requester_username" {
+  description = "CyberArk Identity username of the engineer who requested the account"
+  type        = string
+}
+
+variable "auditor_group" {
+  description = "CyberArk Identity group to assign ReadOnly audit access (leave empty to skip)"
+  type        = string
+  default     = ""
+}
+
+variable "cloudops_group" {
+  description = "CyberArk Identity group to assign Admin access (leave empty to skip)"
+  type        = string
+  default     = ""
+}

--- a/use-cases/aws-account-vending/main.tf
+++ b/use-cases/aws-account-vending/main.tf
@@ -1,15 +1,23 @@
-# AWS Account Vending - Root Configuration
+# AWS Account Vending — Root Configuration
 #
-# This is the root Terraform configuration that orchestrates AWS account
-# provisioning using CyberArk Identity authentication.
+# Orchestrates: account creation → IAM access roles → CyberArk Identity policies
+# All three layers are defined as code so access governance lives alongside
+# the infrastructure it governs.
+#
+# TODO: Replace cyberark-policy module with Secure Cloud Access (SCA) resources
+#       once the correct idsec provider resource types are confirmed.
 
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
+    }
+    idsec = {
+      source  = "cyberark/idsec"
+      version = "~> 1.0"
     }
   }
 
@@ -23,8 +31,8 @@ terraform {
   # }
 }
 
-# Configure AWS Provider
-# Assumes credentials are provided via environment or IAM role
+# ── Providers ─────────────────────────────────────────────────────────────────
+
 provider "aws" {
   region = "us-east-1"
 
@@ -38,14 +46,14 @@ provider "aws" {
   }
 }
 
-# Authenticate with CyberArk Identity
-module "cyberark_auth" {
-  source = "../../modules/cyberark-auth"
-
-  cyberark_token = var.cyberark_token
+provider "idsec" {
+  tenant_url    = var.cyberark_tenant_url
+  client_id     = var.cyberark_client_id
+  client_secret = var.cyberark_client_secret
 }
 
-# Provision AWS Account
+# ── AWS Account ───────────────────────────────────────────────────────────────
+
 module "aws_account" {
   source = "../../modules/aws-account"
 
@@ -54,27 +62,44 @@ module "aws_account" {
   environment   = var.environment
   owner_team    = var.owner_team
 
-  # Use authentication from CyberArk
-  # depends_on = [module.cyberark_auth]
-
   tags = {
-    ProvisionedBy = "GitHubActions"
-    Timestamp     = timestamp()
+    ProvisionedBy   = "GitHubActions"
+    RequesterGitHub = var.requester_username
+    Timestamp       = timestamp()
   }
 }
 
-# Configure IAM Policies and Roles
+# ── IAM Cross-Account Access Roles ───────────────────────────────────────────
+
 module "aws_iam_policies" {
   source = "../../modules/aws-iam-policies"
 
-  account_id  = module.aws_account.account_id
-  environment = var.environment
-  owner_team  = var.owner_team
+  account_id            = module.aws_account.account_id
+  account_name          = var.account_name
+  environment           = var.environment
+  owner_team            = var.owner_team
+  management_account_id = data.aws_caller_identity.current.account_id
+  require_mfa           = var.environment == "prod"
 
-  create_admin_role     = true
-  create_developer_role = true
-  create_readonly_role  = true
-  require_mfa           = var.environment == "prod" ? true : false
-
-  # depends_on = [module.aws_account]
+  depends_on = [module.aws_account]
 }
+
+# ── CyberArk Identity Access Policies ────────────────────────────────────────
+# TODO: Replace with SCA-native resources — idsec_role is a placeholder.
+
+module "cyberark_policy" {
+  source = "../../modules/cyberark-policy"
+
+  account_id         = module.aws_account.account_id
+  account_name       = var.account_name
+  environment        = var.environment
+  requester_username = var.requester_username
+  auditor_group      = var.cyberark_auditor_group
+  cloudops_group     = var.cyberark_cloudops_group
+
+  depends_on = [module.aws_account]
+}
+
+# ── Data sources ──────────────────────────────────────────────────────────────
+
+data "aws_caller_identity" "current" {}

--- a/use-cases/aws-account-vending/variables.tf
+++ b/use-cases/aws-account-vending/variables.tf
@@ -1,5 +1,3 @@
-# AWS Account Vending - Variables
-
 variable "account_name" {
   description = "Name of the AWS account to be created"
   type        = string
@@ -25,9 +23,42 @@ variable "owner_team" {
   type        = string
 }
 
-variable "cyberark_token" {
-  description = "OAuth2 access token from CyberArk Identity"
+variable "requester_username" {
+  description = "GitHub / CyberArk Identity username of the engineer who opened the issue"
+  type        = string
+  default     = ""
+}
+
+# ── CyberArk Identity ─────────────────────────────────────────────────────────
+
+variable "cyberark_tenant_url" {
+  description = "CyberArk Identity tenant URL (e.g. https://abc1234.id.cyberark.cloud)"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_client_id" {
+  description = "OAuth2 service account client ID"
   type        = string
   sensitive   = true
+  default     = ""
+}
+
+variable "cyberark_client_secret" {
+  description = "OAuth2 service account client secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "cyberark_auditor_group" {
+  description = "CyberArk Identity group to assign ReadOnly audit access"
+  type        = string
+  default     = ""
+}
+
+variable "cyberark_cloudops_group" {
+  description = "CyberArk Identity group to assign Admin access"
+  type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

Implements Terraform modules for post-provisioning access governance. The architecture is correct (policy as code, versioned alongside the infrastructure), but the CyberArk resource types need to be reworked to use **Secure Cloud Access (SCA)** policies rather than generic `idsec_role` identity roles.

> **Status: Draft — do not merge.** The `modules/cyberark-policy/` module uses `idsec_role` and `idsec_role_member` as placeholders. These need to be replaced with the correct SCA-native resource types before this is production-ready.

## What changed

| File | Change |
|---|---|
| `modules/cyberark-policy/main.tf` | New — `idsec_role` per tier (poweruser, audit, cloudopsadmin) + `idsec_role_member` assignments |
| `modules/cyberark-policy/variables.tf` | New — account_id, account_name, environment, requester_username, auditor_group, cloudops_group |
| `modules/cyberark-policy/outputs.tf` | New — role IDs and names for all three tiers |
| `modules/aws-iam-policies/main.tf` | Implemented — RequesterPowerUser, AuditorReadOnly, CloudOpsAdmin IAM roles with cross-account trust |
| `modules/aws-iam-policies/variables.tf` | Updated — account_name, management_account_id, require_mfa |
| `modules/aws-iam-policies/outputs.tf` | Updated — real ARN/name outputs |
| `use-cases/aws-account-vending/main.tf` | Adds idsec provider + cyberark-policy module + updated IAM module wiring |
| `use-cases/aws-account-vending/variables.tf` | Adds cyberark_tenant_url, client_id, client_secret, auditor_group, cloudops_group, requester_username |

## Known issues / TODO

- [ ] Replace `idsec_role` / `idsec_role_member` with Secure Cloud Access policy resources
- [ ] Confirm correct SCA Terraform resource types from CyberArk provider docs
- [ ] Add workflow steps to pass CyberArk credentials to Terraform (blocked on SCA resource design)
- [ ] Add SCA policy revocation to the deprovision workflow

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB)_