### PR TITLE
fix: absolute URL for Refresh Issue Templates link in forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/aws-account-deprovision.yml
+++ b/.github/ISSUE_TEMPLATE/aws-account-deprovision.yml
@@ -8,7 +8,7 @@ body:
       value: |
         ## AWS Account Deprovisioning Request
 
-        **Before submitting:** run the [Refresh Issue Templates](../../actions/workflows/refresh-issue-templates.yml)
+        **Before submitting:** run the [Refresh Issue Templates](https://github.com/magicmarkh/pan_id/actions/workflows/refresh-issue-templates.yml)
         workflow so the dropdown below reflects currently active accounts.
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/aws-account-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-account-request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         ## AWS Account Provisioning Request
 
-        **Before submitting:** run the [Refresh Issue Templates](../../actions/workflows/refresh-issue-templates.yml)
+        **Before submitting:** run the [Refresh Issue Templates](https://github.com/magicmarkh/pan_id/actions/workflows/refresh-issue-templates.yml)
         workflow so the dropdowns below reflect current AWS state.
 
   - type: dropdown


### PR DESCRIPTION
## Summary

Fixes the broken "Refresh Issue Templates" link in both issue forms.

GitHub renders `../../actions/workflows/...` relative to the new-issue page URL, which strips the repository path and produces a 404 (`https://github.com/actions/workflows/refresh-issue-templates.yml`). Replaced with the full absolute URL in both templates.

## Files changed

- `.github/ISSUE_TEMPLATE/aws-account-request.yml`
- `.github/ISSUE_TEMPLATE/aws-account-deprovision.yml`

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB)_