### PR TITLE
fix: jq -c flag to prevent GITHUB_OUTPUT parse error in refresh workflow

### DIFF
--- a/.github/workflows/refresh-issue-templates.yml
+++ b/.github/workflows/refresh-issue-templates.yml
@@ -62,7 +62,7 @@ jobs:
                 --query 'Account.Name' \
                 --output text)
               ENTRY=$(printf '{"id":"%s","name":"%s"}' "$ACCOUNT_ID" "$NAME")
-              AVAILABLE_JSON=$(echo "$AVAILABLE_JSON" | jq --argjson e "$ENTRY" '. + [$e]')
+              AVAILABLE_JSON=$(echo "$AVAILABLE_JSON" | jq -c --argjson e "$ENTRY" '. + [$e]')
             fi
           done
 
@@ -86,7 +86,7 @@ jobs:
               --query 'Account.Name' \
               --output text)
             ENTRY=$(printf '{"id":"%s","name":"%s"}' "$ACCOUNT_ID" "$NAME")
-            ACTIVE_JSON=$(echo "$ACTIVE_JSON" | jq --argjson e "$ENTRY" '. + [$e]')
+            ACTIVE_JSON=$(echo "$ACTIVE_JSON" | jq -c --argjson e "$ENTRY" '. + [$e]')
           done
 
           echo "active_accounts=$ACTIVE_JSON" >> $GITHUB_OUTPUT
@@ -113,7 +113,7 @@ jobs:
               --query 'OrganizationalUnit.Name' \
               --output text)
             ENTRY=$(printf '{"id":"%s","name":"%s"}' "$OU_ID" "$OU_NAME")
-            OU_JSON=$(echo "$OU_JSON" | jq --argjson e "$ENTRY" '. + [$e]')
+            OU_JSON=$(echo "$OU_JSON" | jq -c --argjson e "$ENTRY" '. + [$e]')
           done
 
           echo "target_ous=$OU_JSON" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes `Error: Unable to process file command 'output' successfully. Error: Invalid format '  {'` in the Refresh Issue Templates workflow.

`jq` without `-c` writes pretty-printed JSON with newlines and indentation. When that's echoed into `$GITHUB_OUTPUT` as `key=<value>`, the newlines inside the value break the `key=value` line format that GitHub Actions requires.

Added `-c` (compact/single-line output) to all three array-building `jq` calls: `available_accounts`, `active_accounts`, `target_ous`.

## Files changed

- `.github/workflows/refresh-issue-templates.yml` — 3-line change

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB)_