### PR TITLE
fix: exclude Unused OU accounts from deprovision dropdown

### DIFF
--- a/.github/workflows/refresh-issue-templates.yml
+++ b/.github/workflows/refresh-issue-templates.yml
@@ -80,6 +80,13 @@ jobs:
         id: active_accounts
         run: |
           MGMT_ACCOUNT_ID="${{ secrets.AWS_MANAGEMENT_ACCOUNT_ID }}"
+          UNUSED_OU_ID="${{ secrets.AWS_UNUSED_OU_ID }}"
+
+          # Build exclusion set from the Unused OU (accounts not yet configured)
+          UNUSED_IDS=$(aws organizations list-accounts-for-parent \
+            --parent-id "$UNUSED_OU_ID" \
+            --query 'Accounts[*].Id' \
+            --output text | tr '\t' '\n')
 
           ACCOUNT_IDS=$(aws organizations list-accounts \
             --query 'Accounts[?Status==`ACTIVE`].Id' \
@@ -87,8 +94,13 @@ jobs:
 
           ACTIVE_JSON="[]"
           for ACCOUNT_ID in $ACCOUNT_IDS; do
-            # Never offer the management account for deprovisioning
+            # Skip management account
             if [ "$ACCOUNT_ID" = "$MGMT_ACCOUNT_ID" ]; then
+              continue
+            fi
+
+            # Skip accounts sitting in the Unused OU
+            if echo "$UNUSED_IDS" | grep -qx "$ACCOUNT_ID"; then
               continue
             fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ pan_id/
 | `AWS_MANAGEMENT_ACCOUNT_ID` | 12-digit management account ID (used to construct IAM role ARNs) |
 | `AWS_POOL_OU_ID` | OU ID containing pre-staged lab accounts |
 | `AWS_ACTIVE_OU_ID` | OU ID where assigned/active accounts live |
+| `AWS_UNUSED_OU_ID` | OU ID for unprovisioned/unconfigured accounts (excluded from deprovision dropdown) |
 | `SCA_POWER_USER_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for power user access |
 | `SCA_AUDIT_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for audit read-only |
 | `SCA_CLOUDOPS_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for cloud ops admin |


### PR DESCRIPTION
Accounts in the Unused OU are unconfigured and should not appear as deprovision candidates. Build an exclusion set from AWS_UNUSED_OU_ID before iterating all org accounts, alongside the existing management account exclusion.

New secret required: AWS_UNUSED_OU_ID — the OU ID of the Unused container.

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB