### PR TITLE
fix: replace curl role revocation with terraform destroy for SCA poli…

### DIFF
--- a/.github/workflows/aws-account-deprovision.yml
+++ b/.github/workflows/aws-account-deprovision.yml
@@ -8,6 +8,7 @@ permissions:
   issues: write
   contents: read
   id-token: write
+  actions: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -62,18 +63,105 @@ jobs:
           aws-region: us-east-1
           role-session-name: GitHubActions-Deprovision-${{ github.run_id }}
 
+      - name: Find SCA state artifact
+        id: find_sca_state
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const accountId = "${{ needs.parse-request.outputs.account_id }}";
+            const artifactName = `sca-tfstate-${accountId}`;
+
+            const { data } = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: artifactName,
+              per_page: 10
+            });
+
+            const active = data.artifacts
+              .filter(a => !a.expired)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            if (active.length === 0) {
+              core.warning(`No active SCA state artifact found for account ${accountId} — skipping policy removal`);
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            core.setOutput('found', 'true');
+            core.setOutput('run_id', String(active[0].workflow_run.id));
+            console.log(`Found artifact ${artifactName} from run ${active[0].workflow_run.id}`);
+
+      - name: Download SCA Terraform state
+        if: steps.find_sca_state.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: sca-tfstate-${{ needs.parse-request.outputs.account_id }}
+          path: ./use-cases/cyberark-sca-policy
+          run-id: ${{ steps.find_sca_state.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Terraform
+        if: steps.find_sca_state.outputs.found == 'true'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.9"
+
+      - name: Terraform Init (SCA Policies)
+        if: steps.find_sca_state.outputs.found == 'true'
+        working-directory: ./use-cases/cyberark-sca-policy
+        run: terraform init
+
+      - name: Parse account name from selection
+        if: steps.find_sca_state.outputs.found == 'true'
+        id: parse_account_name
+        run: |
+          # Dropdown format: "Account Name | 123456789012" — extract the name part
+          SELECTION="${{ needs.parse-request.outputs.active_account }}"
+          ACCOUNT_NAME=$(echo "$SELECTION" | awk -F' | ' '{print $1}' | xargs)
+          echo "account_name=$ACCOUNT_NAME" >> $GITHUB_OUTPUT
+
+      - name: Terraform Destroy (SCA Policies)
+        if: steps.find_sca_state.outputs.found == 'true'
+        working-directory: ./use-cases/cyberark-sca-policy
+        env:
+          TF_VAR_cyberark_subdomain: ${{ secrets.CYBERARK_SUBDOMAIN }}
+          TF_VAR_cyberark_client_id: ${{ secrets.CYBERARK_CLIENT_ID }}
+          TF_VAR_cyberark_client_secret: ${{ secrets.CYBERARK_CLIENT_SECRET }}
+          TF_VAR_account_id: ${{ needs.parse-request.outputs.account_id }}
+          TF_VAR_account_name: ${{ steps.parse_account_name.outputs.account_name }}
+          TF_VAR_requester_username: placeholder
+          TF_VAR_power_user_permission_set_arn: ${{ secrets.SCA_POWER_USER_PERMISSION_SET_ARN }}
+          TF_VAR_audit_permission_set_arn: ${{ secrets.SCA_AUDIT_PERMISSION_SET_ARN }}
+          TF_VAR_cloudops_permission_set_arn: ${{ secrets.SCA_CLOUDOPS_PERMISSION_SET_ARN }}
+          TF_VAR_audit_group_name: ${{ secrets.SCA_AUDIT_GROUP_NAME }}
+          TF_VAR_cloudops_group_name: ${{ secrets.SCA_CLOUDOPS_GROUP_NAME }}
+        run: terraform destroy -auto-approve -no-color
+
+      - name: No SCA state found
+        if: steps.find_sca_state.outputs.found != 'true'
+        run: echo "⚠️ No SCA policies state found — skipping policy removal"
+
       - name: Return account to pool (Simulate)
         if: needs.parse-request.outputs.mode == 'Simulate'
         id: return_account
         run: |
           ACCOUNT_ID="${{ needs.parse-request.outputs.account_id }}"
           POOL_OU_ID="${{ secrets.AWS_POOL_OU_ID }}"
-          ACTIVE_OU_ID="${{ secrets.AWS_ACTIVE_OU_ID }}"
+
+          # Dynamically find the account's current parent — works regardless of which OU it's in
+          CURRENT_PARENT=$(aws organizations list-parents \
+            --child-id "$ACCOUNT_ID" \
+            --query 'Parents[0].Id' \
+            --output text)
+
+          echo "Current parent: $CURRENT_PARENT"
 
           # Move back to pool OU
           aws organizations move-account \
             --account-id "$ACCOUNT_ID" \
-            --source-parent-id "$ACTIVE_OU_ID" \
+            --source-parent-id "$CURRENT_PARENT" \
             --destination-parent-id "$POOL_OU_ID"
 
           echo "✅ Moved account back to pool OU"
@@ -98,63 +186,25 @@ jobs:
 
           echo "✅ Deprovisioning complete"
 
-      - name: Revoke CyberArk access roles (Simulate)
-        if: needs.parse-request.outputs.mode == 'Simulate'
-        env:
-          ACCOUNT_ID: ${{ needs.parse-request.outputs.account_id }}
-          TENANT_URL: ${{ secrets.CYBERARK_TENANT_URL }}
-        run: |
-          # Obtain token
-          RESPONSE=$(curl -s -X POST \
-            "${TENANT_URL}/oauth2/platformtoken" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials&client_id=${{ secrets.CYBERARK_CLIENT_ID }}&client_secret=${{ secrets.CYBERARK_CLIENT_SECRET }}")
-
-          TOKEN=$(echo "$RESPONSE" | jq -r '.access_token // empty')
-          if [ -z "$TOKEN" ]; then
-            echo "⚠️ Could not obtain CyberArk token — skipping role revocation (non-fatal)"
-            exit 0
-          fi
-          echo "::add-mask::$TOKEN"
-
-          BASE_URL="${TENANT_URL}/api/idadmin"
-          AUTH_HEADER="Authorization: Bearer ${TOKEN}"
-
-          # Fetch role IDs by name pattern and delete them
-          for SUFFIX in poweruser audit cloudopsadmin; do
-            # Get role ID by name (search)
-            ROLE_NAME="aws-*-${SUFFIX}"
-            ROLES=$(curl -s -X POST "${BASE_URL}/Roles/GetRolesAndRightsForCurrentUser" \
-              -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-              -d "{}" | jq -r --arg pat "aws-" '.Result[]? | select(.Name | startswith($pat)) | select(.Name | endswith("'"${SUFFIX}"'")) | .ID // empty')
-
-            for ROLE_ID in $ROLES; do
-              curl -s -X POST "${BASE_URL}/Roles/DeleteRole" \
-                -H "$AUTH_HEADER" -H "Content-Type: application/json" \
-                -d "{\"ID\":\"${ROLE_ID}\"}" > /dev/null
-              echo "✅ Deleted CyberArk role: $ROLE_ID"
-            done
-          done
-
-          echo "✅ CyberArk role cleanup complete (or no roles found)"
-
       - name: Comment Success on Issue
         if: success()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const scaRemoved = "${{ steps.find_sca_state.outputs.found }}" === "true";
+            const scaNote = scaRemoved
+              ? "\n- 🔐 CyberArk SCA policies removed"
+              : "\n- ⚠️ No CyberArk SCA state found — policies may need manual cleanup";
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `### ✅ Account Returned to Pool
 
-              Account \`${{ needs.parse-request.outputs.account_id }}\` has been
-              returned to the lab pool, tagged **Available**, and CyberArk access
-              roles have been revoked.
-
-              The account is ready for the next demo.`
+              Account \`${{ needs.parse-request.outputs.account_id }}\` has been deprovisioned:
+              - ✅ Returned to lab pool (tagged Available)${scaNote}`
             });
 
       - name: Close Issue


### PR DESCRIPTION
…cies

The old approach used bash curl calls to delete CyberArk roles by name, which required CYBERARK_TENANT_URL (unset) and was tied to the deprecated idsec_role resource design.

New approach:
- Find sca-tfstate-{account_id} artifact from the provisioning run
- Download state and run terraform destroy on use-cases/cyberark-sca-policy/
- Uses CYBERARK_SUBDOMAIN + permission set ARN secrets (no TENANT_URL needed)
- Dynamic list-parents lookup replaces hardcoded ACTIVE_OU_ID for move-account
- actions: read permission added for cross-workflow artifact download

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB