### PR TITLE
feat: multi-account deprovisioning + fix duplicate description attribute

### DIFF
--- a/modules/cyberark-policy/variables.tf
+++ b/modules/cyberark-policy/variables.tf
@@ -1,5 +1,4 @@
 variable "account_id" {
-  description = "AWS account ID of the provisioned account"
   description = "12-digit AWS account ID"
   type        = string
 }


### PR DESCRIPTION
## Summary

- Aligns `cyberark-policy` module with the actual `idsec_policy_cloud_access` schema (verified via `terraform providers schema -json`)
- Multi-account deprovisioning in a single issue
- Hotfix for `terraform init` duplicate-`description` failure

## Schema corrections (`modules/cyberark-policy/main.tf`)

| Before | After | Why |
|---|---|---|
| `status = "Active"` | *(removed)* | `status` is a computed object the provider returns — can't be set |
| `target_category = "AWS"` | `"Cloud console"` | Schema lists valid values: Cloud console, Groups, VM, DB |
| `location_type = "Public Cloud"` | `"AWS"` | Schema lists valid values: AWS, Azure, GCP, FQDN/IP |
| `policy_type = "Privileged Access"` | `"Recurring"` | Schema: Recurring or OnDemand |
| `time_restrictions = {...}` | `access_window = {...}` | `time_restrictions` does not exist; schema attribute is `access_window` |
| `enforcement_type / from / to / days` | `days_of_the_week (numeric set Sun=0) / from_hour / to_hour (ISO 8601)` | Schema requires numeric day codes and full ISO 8601 datetimes |
| `max_session_duration = 3600` (seconds) | `1` (hours) | Schema says hours, default 1 |

## Multi-account deprovisioning

- Issue template `active_account` dropdown now has `multiple: true`
- Workflow `parse-request` outputs `accounts_json` (JSON array of `{id, name}`)
- `deprovision-account` is a matrix job (one parallel runner per account, `fail-fast: false`)
- New `notify` job posts a single summary comment, closes issue, triggers refresh — only if all matrix items succeeded

## Variables

`max_session_duration` default changed from 3600 to 1 in both `modules/cyberark-policy/variables.tf` and `use-cases/cyberark-sca-policy/variables.tf` (units: hours, not seconds)

## Test plan

- [ ] `terraform apply` in `use-cases/cyberark-sca-policy/` succeeds for a provision request
- [ ] Three policies appear in CyberArk SCA: `aws-{name}-poweruser`, `-audit`, `-cloudops`
- [ ] Each policy is Recurring, Mon-Fri 08:00-18:00 UTC, 1 hour max session
- [ ] Multi-account deprovision: select 2+ accounts, each runs in its own runner, single summary comment

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB