### PR TITLE
fix: correct principal type casing and delegation_classification values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,10 +216,10 @@ The `refresh-issue-templates.yml` workflow reads these tags to populate dropdown
 - `status`, `created_by`, `updated_on`, `policy_id` are **computed/read-only** — DO NOT set
 
 **`delegation_classification`** (optional, string, default `"Unrestricted"`)
-- For privileged demos, set to `"Privileged"`
+- Valid values: `"Unrestricted"`, `"Restricted"` — NOT `"Privileged"`
 
 **`principals`** (list of objects)
-- `name`, `type` (User/Group/Role), optional `id`, `source_directory_id`, `source_directory_name`
+- `name`, `type` (`USER`/`GROUP`/`ROLE` — **uppercase**), optional `id`, `source_directory_id`, `source_directory_name`
 
 **`targets.aws_account_targets`** (list of objects)
 - `role_id` (required) = IAM Identity Center **permission set ARN** (NOT an IAM role ARN — SCA federates through IAM Identity Center)

--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -30,12 +30,12 @@ resource "idsec_policy_cloud_access" "power_user" {
     time_zone = "UTC"
   }
 
-  delegation_classification = "Privileged"
+  delegation_classification = "Unrestricted"
 
   principals = [
     {
       name = var.requester_username
-      type = "User"
+      type = "USER"
     }
   ]
 
@@ -66,12 +66,12 @@ resource "idsec_policy_cloud_access" "audit" {
     time_zone = "UTC"
   }
 
-  delegation_classification = "Privileged"
+  delegation_classification = "Unrestricted"
 
   principals = [
     {
       name = var.audit_group_name
-      type = "Group"
+      type = "GROUP"
     }
   ]
 
@@ -102,12 +102,12 @@ resource "idsec_policy_cloud_access" "cloudops" {
     time_zone = "UTC"
   }
 
-  delegation_classification = "Privileged"
+  delegation_classification = "Unrestricted"
 
   principals = [
     {
       name = var.cloudops_group_name
-      type = "Group"
+      type = "GROUP"
     }
   ]
 


### PR DESCRIPTION
Provider validation errors:
- principals[].type must be USER/GROUP/ROLE (uppercase) — was "User"/"Group"
- delegation_classification must be "Unrestricted" or "Restricted" — was "Privileged" which is not a valid value

CLAUDE.md updated to record correct enum values so future changes don't repeat these.

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB