### PR TITLE
fix: reference metadata.policy_id instead of nonexistent top-level id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,7 @@ The `refresh-issue-templates.yml` workflow reads these tags to populate dropdown
 - `time_zone` (optional, default `"GMT"`)
 - `time_frame.from_time` / `to_time` (optional ISO 8601 `yyyy-MM-ddTHH:mm:ss`)
 - `status`, `created_by`, `updated_on`, `policy_id` are **computed/read-only** — DO NOT set
+- The resource has **no top-level `id` attribute**. The policy ID is `<resource>.metadata.policy_id`
 
 **`delegation_classification`** (optional, string, default `"Unrestricted"`)
 - Valid values: `"Unrestricted"`, `"Restricted"` — NOT `"Privileged"`

--- a/modules/cyberark-policy/outputs.tf
+++ b/modules/cyberark-policy/outputs.tf
@@ -1,14 +1,14 @@
 output "power_user_policy_id" {
   description = "ID of the CyberArk SCA policy for power user access"
-  value       = idsec_policy_cloud_access.power_user.id
+  value       = idsec_policy_cloud_access.power_user.metadata.policy_id
 }
 
 output "audit_policy_id" {
   description = "ID of the CyberArk SCA policy for audit access"
-  value       = idsec_policy_cloud_access.audit.id
+  value       = idsec_policy_cloud_access.audit.metadata.policy_id
 }
 
 output "cloudops_policy_id" {
   description = "ID of the CyberArk SCA policy for cloud ops access"
-  value       = idsec_policy_cloud_access.cloudops.id
+  value       = idsec_policy_cloud_access.cloudops.metadata.policy_id
 }


### PR DESCRIPTION
The idsec_policy_cloud_access resource has no top-level id attribute. The computed policy ID is exposed as metadata.policy_id per the provider schema.

CLAUDE.md note added so this isn't relearned.

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB