### PR TITLE
chore: rename SCA group secrets to match existing CYBERARK_*_GROUP names

### DIFF
--- a/.github/workflows/aws-account-deprovision.yml
+++ b/.github/workflows/aws-account-deprovision.yml
@@ -138,8 +138,8 @@ jobs:
           TF_VAR_power_user_permission_set_arn: ${{ secrets.SCA_POWER_USER_PERMISSION_SET_ARN }}
           TF_VAR_audit_permission_set_arn: ${{ secrets.SCA_AUDIT_PERMISSION_SET_ARN }}
           TF_VAR_cloudops_permission_set_arn: ${{ secrets.SCA_CLOUDOPS_PERMISSION_SET_ARN }}
-          TF_VAR_audit_group_name: ${{ secrets.SCA_AUDIT_GROUP_NAME }}
-          TF_VAR_cloudops_group_name: ${{ secrets.SCA_CLOUDOPS_GROUP_NAME }}
+          TF_VAR_audit_group_name: ${{ secrets.CYBERARK_AUDITOR_GROUP }}
+          TF_VAR_cloudops_group_name: ${{ secrets.CYBERARK_CLOUDOPS_GROUP }}
         run: terraform destroy -auto-approve -no-color
 
       - name: No SCA state found

--- a/.github/workflows/aws-account-vending.yml
+++ b/.github/workflows/aws-account-vending.yml
@@ -355,8 +355,8 @@ jobs:
           TF_VAR_power_user_permission_set_arn: ${{ secrets.SCA_POWER_USER_PERMISSION_SET_ARN }}
           TF_VAR_audit_permission_set_arn: ${{ secrets.SCA_AUDIT_PERMISSION_SET_ARN }}
           TF_VAR_cloudops_permission_set_arn: ${{ secrets.SCA_CLOUDOPS_PERMISSION_SET_ARN }}
-          TF_VAR_audit_group_name: ${{ secrets.SCA_AUDIT_GROUP_NAME }}
-          TF_VAR_cloudops_group_name: ${{ secrets.SCA_CLOUDOPS_GROUP_NAME }}
+          TF_VAR_audit_group_name: ${{ secrets.CYBERARK_AUDITOR_GROUP }}
+          TF_VAR_cloudops_group_name: ${{ secrets.CYBERARK_CLOUDOPS_GROUP }}
         run: terraform apply -auto-approve -no-color
 
       - name: Upload SCA Terraform state
@@ -385,8 +385,8 @@ jobs:
               | Policy | Principals |
               |---|---|
               | **PowerUser** | @${{ needs.parse-request.outputs.requester }} |
-              | **Audit** | ${{ secrets.SCA_AUDIT_GROUP_NAME }} (group) |
-              | **CloudOps** | ${{ secrets.SCA_CLOUDOPS_GROUP_NAME }} (group) |
+              | **Audit** | ${{ secrets.CYBERARK_AUDITOR_GROUP }} (group) |
+              | **CloudOps** | ${{ secrets.CYBERARK_CLOUDOPS_GROUP }} (group) |
 
               Access is available via CyberArk Secure Cloud Access. Sessions limited to 1 hour, Mon–Fri 08:00–18:00 UTC.`
             });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,8 @@ pan_id/
 | `SCA_POWER_USER_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for power user access |
 | `SCA_AUDIT_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for audit read-only |
 | `SCA_CLOUDOPS_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for cloud ops admin |
-| `SCA_AUDIT_GROUP_NAME` | CyberArk group name for auditors |
-| `SCA_CLOUDOPS_GROUP_NAME` | CyberArk group name for cloud ops |
+| `CYBERARK_AUDITOR_GROUP` | CyberArk group name for auditors |
+| `CYBERARK_CLOUDOPS_GROUP` | CyberArk group name for cloud ops |
 
 ## GitHub Environment Required
 - Environment name: `production`


### PR DESCRIPTION
The repo already had CYBERARK_AUDITOR_GROUP and CYBERARK_CLOUDOPS_GROUP secrets; the workflow expected SCA_AUDIT_GROUP_NAME and SCA_CLOUDOPS_GROUP_NAME. Aligned the workflow to the existing names so no secrets need to be re-created.

Updated:
- .github/workflows/aws-account-vending.yml (TF env vars + success comment table)
- .github/workflows/aws-account-deprovision.yml (TF env vars)
- CLAUDE.md (Required Secrets table)

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB