### PR TITLE
docs: remove CYBERARK_TENANT_URL from required secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,6 @@ pan_id/
 ## GitHub Secrets Required
 | Secret | Description |
 |---|---|
-| `CYBERARK_TENANT_URL` | CyberArk tenant URL e.g. `https://abc1234.id.cyberark.cloud` (used by legacy curl steps; SCA uses `CYBERARK_SUBDOMAIN`) |
 | `CYBERARK_SUBDOMAIN` | Tenant subdomain only e.g. `abc1234` (used by idsec Terraform provider) |
 | `CYBERARK_CLIENT_ID` | OAuth2 service account client ID (`service_user` in idsec provider) |
 | `CYBERARK_CLIENT_SECRET` | OAuth2 service account client secret (`service_token` in idsec provider) |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This system provides a self-service AWS account vending machine that:
 ### Prerequisites
 
 1. **GitHub Repository Secrets**: Configure the following secrets in your repository settings:
-   - `CYBERARK_TENANT_URL`: Your CyberArk Identity tenant URL (e.g., `https://your-tenant.cyberark.cloud`)
+   - `CYBERARK_SUBDOMAIN`: Tenant subdomain only (e.g. `abc1234`, not the full URL)
    - `CYBERARK_CLIENT_ID`: OAuth2 client ID for CyberArk Identity
    - `CYBERARK_CLIENT_SECRET`: OAuth2 client secret for CyberArk Identity
 


### PR DESCRIPTION
The legacy curl-based CyberArk role revocation steps that used CYBERARK_TENANT_URL have all been removed in favor of terraform destroy on idsec_policy_cloud_access. The idsec provider only needs CYBERARK_SUBDOMAIN. Cleaned up README + CLAUDE.md so the secret list matches what the workflows actually consume.

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB