### PR TITLE
feat: lock provision/deprovision pipeline to strict two-OU model

### DIFF
--- a/.github/workflows/aws-account-deprovision.yml
+++ b/.github/workflows/aws-account-deprovision.yml
@@ -151,6 +151,7 @@ jobs:
         run: |
           ACCOUNT_ID="${{ matrix.account.id }}"
           POOL_OU_ID="${{ secrets.AWS_POOL_OU_ID }}"
+          ACTIVE_OU_ID="${{ secrets.AWS_ACTIVE_OU_ID }}"
 
           CURRENT_PARENT=$(aws organizations list-parents \
             --child-id "$ACCOUNT_ID" \
@@ -159,14 +160,20 @@ jobs:
 
           echo "Current parent: $CURRENT_PARENT"
 
+          # Two-OU safety guard: only move accounts that are currently in the active OU
+          # or already in the pool OU. Refuse to touch accounts in other demo OUs.
           if [ "$CURRENT_PARENT" = "$POOL_OU_ID" ]; then
             echo "⚠️ Account is already in pool OU — skipping move"
-          else
+          elif [ "$CURRENT_PARENT" = "$ACTIVE_OU_ID" ]; then
             aws organizations move-account \
               --account-id "$ACCOUNT_ID" \
-              --source-parent-id "$CURRENT_PARENT" \
+              --source-parent-id "$ACTIVE_OU_ID" \
               --destination-parent-id "$POOL_OU_ID"
             echo "✅ Moved account back to pool OU"
+          else
+            echo "❌ Account $ACCOUNT_ID is in OU $CURRENT_PARENT (not the active OU)."
+            echo "   Refusing to move — this account belongs to another demo environment."
+            exit 1
           fi
 
           aws organizations untag-resource \

--- a/.github/workflows/refresh-issue-templates.yml
+++ b/.github/workflows/refresh-issue-templates.yml
@@ -76,34 +76,20 @@ jobs:
           echo "available_accounts=$AVAILABLE_JSON" >> $GITHUB_OUTPUT
           echo "Found $(echo "$AVAILABLE_JSON" | jq length) available pool accounts"
 
-      - name: Query all deprovisionable accounts
+      - name: Query active OU accounts (deprovisionable)
         id: active_accounts
         run: |
-          MGMT_ACCOUNT_ID="${{ secrets.AWS_MANAGEMENT_ACCOUNT_ID }}"
-          UNUSED_OU_ID="${{ secrets.AWS_UNUSED_OU_ID }}"
+          ACTIVE_OU_ID="${{ secrets.AWS_ACTIVE_OU_ID }}"
 
-          # Build exclusion set from the Unused OU (accounts not yet configured)
-          UNUSED_IDS=$(aws organizations list-accounts-for-parent \
-            --parent-id "$UNUSED_OU_ID" \
-            --query 'Accounts[*].Id' \
-            --output text | tr '\t' '\n')
-
-          ACCOUNT_IDS=$(aws organizations list-accounts \
+          # Two-OU model: only accounts currently in the active OU are deprovisionable.
+          # Accounts in other OUs (other demo environments) are intentionally excluded.
+          ACCOUNT_IDS=$(aws organizations list-accounts-for-parent \
+            --parent-id "$ACTIVE_OU_ID" \
             --query 'Accounts[?Status==`ACTIVE`].Id' \
             --output text)
 
           ACTIVE_JSON="[]"
           for ACCOUNT_ID in $ACCOUNT_IDS; do
-            # Skip management account
-            if [ "$ACCOUNT_ID" = "$MGMT_ACCOUNT_ID" ]; then
-              continue
-            fi
-
-            # Skip accounts sitting in the Unused OU
-            if echo "$UNUSED_IDS" | grep -qx "$ACCOUNT_ID"; then
-              continue
-            fi
-
             NAME=$(aws organizations describe-account \
               --account-id "$ACCOUNT_ID" \
               --query 'Account.Name' \
@@ -113,7 +99,7 @@ jobs:
           done
 
           echo "active_accounts=$ACTIVE_JSON" >> $GITHUB_OUTPUT
-          echo "Found $(echo "$ACTIVE_JSON" | jq length) deprovisionable accounts"
+          echo "Found $(echo "$ACTIVE_JSON" | jq length) deprovisionable accounts in active OU"
 
       - name: Query available target OUs
         id: target_ous

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,10 @@ GitHub Issue Form (multi-select) → GitHub Actions → [production gate]
 ### 4. Refresh Issue Templates (`.github/workflows/refresh-issue-templates.yml`)
 - **Triggers:** daily at 06:00 UTC, `workflow_dispatch`, or `workflow_run` after vending/deprovisioning completes
 - Queries AWS Organizations and rewrites the YAML dropdown options:
-  - Pool OU accounts tagged `Status=Available` → provision form
-  - All org accounts EXCEPT management account and `AWS_UNUSED_OU_ID` accounts → deprovision form
+  - **Pool OU** accounts tagged `Status=Available` → provision form (`pool_account`)
+  - **Active OU** accounts → deprovision form (`active_account`)
   - Direct child OUs of org root → provision form `target_ou`
+- **Two-OU model:** the deprovision dropdown only lists accounts in `AWS_ACTIVE_OU_ID`. Accounts in other OUs (other demo environments) are intentionally invisible and cannot be deprovisioned through this pipeline.
 - Vending and deprovision workflows also call `createWorkflowDispatch` on success for immediate refresh
 
 ## Key Design Decisions (Already Made — Do Not Revisit Unless Asked)
@@ -63,7 +64,7 @@ GitHub Issue Form (multi-select) → GitHub Actions → [production gate]
 - **Issue parsing:** `stefanbuck/github-issue-parser@v3` maps issue form fields to job outputs
 - **Dropdown freshness:** `refresh-issue-templates.yml` queries AWS and rewrites YAML; option format is `"Name | ID"` so workflows can parse the ID back with `awk -F' [|] '`
 - **Multi-account deprovision parsing:** comma-separated multi-select string → JSON array `[{id, name}, ...]` consumed by `strategy.matrix`
-- **OU return on deprovision:** dynamic via `aws organizations list-parents` (works regardless of which OU the account currently sits in); skipped if account is already in pool OU
+- **OU return on deprovision:** uses `aws organizations list-parents` to confirm current parent, then moves only if the account is in the active OU. Skipped if already in pool. Fails if account is in any other OU (defends adjacent demo environments).
 - **SCA policy state:** GitHub Actions artifact (not S3) — sufficient for demo lifecycle (90-day retention)
 - **Terraform state for account vending:** Local (S3 backend stubbed and commented in `main.tf`)
 - **idsec provider version:** `cyberark/idsec >= 0.1.0` (only 0.x releases exist — DO NOT use `~> 1.0`)
@@ -99,10 +100,9 @@ pan_id/
 | `CYBERARK_SUBDOMAIN` | Tenant subdomain only e.g. `abc1234` (used by idsec Terraform provider) |
 | `CYBERARK_CLIENT_ID` | OAuth2 service account client ID (`service_user` in idsec provider) |
 | `CYBERARK_CLIENT_SECRET` | OAuth2 service account client secret (`service_token` in idsec provider) |
-| `AWS_MANAGEMENT_ACCOUNT_ID` | 12-digit management account ID (used to construct IAM role ARNs and to exclude from deprovision dropdown) |
-| `AWS_POOL_OU_ID` | OU ID containing pre-staged lab accounts |
-| `AWS_ACTIVE_OU_ID` | OU ID where assigned/active accounts live |
-| `AWS_UNUSED_OU_ID` | OU ID for unprovisioned/unconfigured accounts (excluded from deprovision dropdown) |
+| `AWS_MANAGEMENT_ACCOUNT_ID` | 12-digit management account ID (used to construct the GitHubActionsOrgProvisioner IAM role ARN) |
+| `AWS_POOL_OU_ID` | OU ID containing pre-staged lab accounts (provision dropdown source) |
+| `AWS_ACTIVE_OU_ID` | OU ID where assigned/active accounts live (deprovision dropdown source) |
 | `SCA_POWER_USER_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for power user access |
 | `SCA_AUDIT_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for audit read-only |
 | `SCA_CLOUDOPS_PERMISSION_SET_ARN` | IAM Identity Center permission set ARN for cloud ops admin |


### PR DESCRIPTION
## Summary

Tightens the provision/deprovision pipeline to a strict **two-OU model** so other demo environments in the same AWS Organization can't be accidentally affected.

## Changes

### Refresh workflow (`refresh-issue-templates.yml`)
- Deprovision dropdown now sourced exclusively from `AWS_ACTIVE_OU_ID` via `list-accounts-for-parent`
- Removed the broad `list-accounts` + management-exclusion + Unused-OU-exclusion logic
- `AWS_UNUSED_OU_ID` is no longer referenced anywhere

### Deprovision workflow (`aws-account-deprovision.yml`)
- After the dynamic `list-parents` lookup, the move step now **refuses to act** on any account whose current parent is neither the active OU nor the pool OU
- Fails with a clear message ("this account belongs to another demo environment") instead of silently moving an account out of an unrelated OU

### Docs (`CLAUDE.md`)
- Use Case #4 explicitly calls out the two-OU contract
- Key Design Decisions updated for the new guard behavior
- `AWS_UNUSED_OU_ID` removed from the Required Secrets table (the secret in your repo can be deleted, but doesn't have to be)

## Test plan

- [ ] Run **Refresh Issue Templates** → verify deprovision dropdown only shows accounts in the active OU (not management, not other demo OUs)
- [ ] Open deprovision issue with an active-OU account → succeeds end-to-end
- [ ] If you can simulate it: open a deprovision issue against an account that's been manually moved to another OU → workflow should fail with the "belongs to another demo environment" message rather than moving it

https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnruZyA6LFSmZJZpZGk7KB)_