### PR TITLE
fix: align idsec_policy_cloud_access payload with working schema

### DIFF
--- a/.github/workflows/aws-account-deprovision.yml
+++ b/.github/workflows/aws-account-deprovision.yml
@@ -134,6 +134,7 @@ jobs:
           TF_VAR_cyberark_client_secret: ${{ secrets.CYBERARK_CLIENT_SECRET }}
           TF_VAR_account_id: ${{ matrix.account.id }}
           TF_VAR_account_name: ${{ matrix.account.name }}
+          TF_VAR_org_management_account_id: ${{ secrets.AWS_MANAGEMENT_ACCOUNT_ID }}
           TF_VAR_power_user_group_name: ${{ secrets.CYBERARK_POWERUSER_GROUP }}
           TF_VAR_power_user_permission_set_arn: ${{ secrets.SCA_POWER_USER_PERMISSION_SET_ARN }}
           TF_VAR_audit_permission_set_arn: ${{ secrets.SCA_AUDIT_PERMISSION_SET_ARN }}

--- a/.github/workflows/aws-account-vending.yml
+++ b/.github/workflows/aws-account-vending.yml
@@ -352,28 +352,14 @@ jobs:
           TF_VAR_cyberark_client_secret: ${{ secrets.CYBERARK_CLIENT_SECRET }}
           TF_VAR_account_id: ${{ needs.provision-account.outputs.account_id }}
           TF_VAR_account_name: ${{ needs.parse-request.outputs.account_name }}
+          TF_VAR_org_management_account_id: ${{ secrets.AWS_MANAGEMENT_ACCOUNT_ID }}
           TF_VAR_power_user_group_name: ${{ secrets.CYBERARK_POWERUSER_GROUP }}
           TF_VAR_power_user_permission_set_arn: ${{ secrets.SCA_POWER_USER_PERMISSION_SET_ARN }}
           TF_VAR_audit_permission_set_arn: ${{ secrets.SCA_AUDIT_PERMISSION_SET_ARN }}
           TF_VAR_cloudops_permission_set_arn: ${{ secrets.SCA_CLOUDOPS_PERMISSION_SET_ARN }}
           TF_VAR_audit_group_name: ${{ secrets.CYBERARK_AUDITOR_GROUP }}
           TF_VAR_cloudops_group_name: ${{ secrets.CYBERARK_CLOUDOPS_GROUP }}
-          TF_LOG: DEBUG
-          TF_LOG_PATH: /tmp/tf-debug.log
         run: terraform apply -auto-approve -no-color
-
-      - name: Surface SCA API error response (debug)
-        if: failure()
-        run: |
-          if [ ! -s /tmp/tf-debug.log ]; then
-            echo "No debug log captured."
-            exit 0
-          fi
-          echo "===== HTTP request/response context around 4xx/5xx ====="
-          grep -n -B 5 -A 60 -E 'HTTP/[12]\.[01] [45][0-9]{2}|"code":[ ]?[45][0-9]{2}|"faultCode":[ ]?[45][0-9]{2}' /tmp/tf-debug.log | head -500 || echo "(no matches)"
-          echo
-          echo "===== last 200 lines of debug log ====="
-          tail -200 /tmp/tf-debug.log
 
       - name: Upload SCA Terraform state
         if: success()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,35 +204,40 @@ The `refresh-issue-templates.yml` workflow reads these tags to populate dropdown
 - Available versions: `0.1.x`–`0.2.x` only (NO `1.x` releases). Use constraint `>= 0.1.0`
 - Provider block uses `auth_method = "identity_service_user"`, `service_user`, `service_token`, `subdomain`
 
-### `idsec_policy_cloud_access` schema (verified via `terraform providers schema -json`)
-**`metadata` (object, required for `name` and `policy_entitlement`)**
-- `name` (required, string)
-- `description` (optional, string, max 200 chars)
-- `policy_entitlement` (required, object):
-  - `target_category` (required) — `"Cloud console"` for AWS console access
-  - `location_type` (required) — `"AWS"`, `"Azure"`, or `"GCP"`
-  - `policy_type` (optional) — `"Recurring"` or `"OnDemand"`
-- `time_zone` (optional, default `"GMT"`)
-- `time_frame.from_time` / `to_time` (optional ISO 8601 `yyyy-MM-ddTHH:mm:ss`)
-- `status`, `created_by`, `updated_on`, `policy_id` are **computed/read-only** — DO NOT set
-- The resource has **no top-level `id` attribute**. The policy ID is `<resource>.metadata.policy_id`
+### `idsec_policy_cloud_access` schema (verified against working policy from CyberArk SE)
 
-**`delegation_classification`** (optional, string, default `"Unrestricted"`)
-- Valid values: `"Unrestricted"`, `"Restricted"` — NOT `"Privileged"`
+The schema as actually accepted by the SCA API differs in several ways from the
+provider's terraform-plugin-framework JSON dump — the dump describes what's
+*parseable*, not what the server *accepts*. Use this section as the source of
+truth; it reflects a payload that creates a policy successfully.
+
+**`metadata`**
+- `name` (required, string)
+- `description` (optional, string)
+- `status = { status = "Active" }` (required to create an enabled policy)
+- `policy_entitlement` (required):
+  - `target_category` = `"Cloud console"` for AWS console access
+  - `location_type` = `"AWS"` / `"Azure"` / `"GCP"`
+  - **DO NOT set `policy_type`** — server 500s
+- `time_zone` (optional) — IANA name e.g. `"America/New_York"`, `"Etc/UTC"`. NOT `"UTC"` (server 500s) and NOT `"GMT"`
+- `policy_tags` (optional, list of string)
 
 **`principals`** (list of objects)
-- `name`, `type` (`USER`/`GROUP`/`ROLE` — **uppercase**), optional `id`, `source_directory_id`, `source_directory_name`
+- `name`, `type` (`USER` / `GROUP` / `ROLE` — uppercase). `source_directory_id` is optional and the server resolves the directory if omitted
 
-**`targets.aws_account_targets`** (list of objects)
-- `role_id` (required) = IAM Identity Center **permission set ARN** (NOT an IAM role ARN — SCA federates through IAM Identity Center)
-- `workspace_id` (required) = 12-digit AWS account ID
+**`targets`**
+- Use `aws_organization_targets` for AWS console access (NOT `aws_account_targets` — that path 500s):
+  - `role_id` (required) = IAM Identity Center permission set ARN
+  - `workspace_id` (required) = 12-digit AWS account ID
+  - `org_id` (required) = the AWS Organizations *management account ID* (12 digits, NOT `o-xxxx` org ID)
 
-**`conditions`** (object)
-- `max_session_duration` (number, **HOURS** not seconds, default 1)
-- `access_window` (object):
-  - `days_of_the_week` — set of numbers (Sun=0, Mon=1, …, Sat=6)
-  - `from_hour` / `to_hour` — ISO 8601 datetimes (date portion ignored for recurring policies)
-- There is NO `time_restrictions` attribute, NO `enforcement_type`, NO string `days` array
+**`conditions`**
+- `max_session_duration` (number, hours, default 1)
+- `access_window`:
+  - `days_of_the_week` — list of numbers, Mon=1 … Sun=7 (NOT Sun=0)
+  - `from_hour` / `to_hour` — `HH:MM:SS` strings (NOT ISO 8601 datetimes — server 500s on those)
+
+**`delegation_classification`** (optional) — `"Unrestricted"` or `"Restricted"`
 
 ## Agent Instructions (Claude Code)
 

--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -10,11 +10,10 @@ terraform {
 }
 
 locals {
-  # Mon-Fri 08:00-18:00 UTC. Date portion is ignored for recurring policies.
   access_window = {
     days_of_the_week = [1, 2, 3, 4, 5]
-    from_hour        = "2024-01-01T08:00:00"
-    to_hour          = "2024-01-01T18:00:00"
+    from_hour        = var.access_window_from_hour
+    to_hour          = var.access_window_to_hour
   }
 }
 
@@ -22,15 +21,15 @@ resource "idsec_policy_cloud_access" "power_user" {
   metadata = {
     name        = "aws-${var.account_name}-poweruser"
     description = "Power user access to ${var.account_name} (${var.account_id})"
+    status = {
+      status = "Active"
+    }
     policy_entitlement = {
       target_category = "Cloud console"
       location_type   = "AWS"
-      policy_type     = "Recurring"
     }
-    time_zone = "UTC"
+    time_zone = var.time_zone
   }
-
-  delegation_classification = "Unrestricted"
 
   principals = [
     {
@@ -39,18 +38,19 @@ resource "idsec_policy_cloud_access" "power_user" {
     }
   ]
 
-  targets = {
-    aws_account_targets = [
-      {
-        role_id      = var.power_user_permission_set_arn
-        workspace_id = var.account_id
-      }
-    ]
-  }
-
   conditions = {
     max_session_duration = var.max_session_duration
     access_window        = local.access_window
+  }
+
+  targets = {
+    aws_organization_targets = [
+      {
+        role_id      = var.power_user_permission_set_arn
+        workspace_id = var.account_id
+        org_id       = var.org_management_account_id
+      }
+    ]
   }
 }
 
@@ -58,15 +58,15 @@ resource "idsec_policy_cloud_access" "audit" {
   metadata = {
     name        = "aws-${var.account_name}-audit"
     description = "Read-only audit access to ${var.account_name} (${var.account_id})"
+    status = {
+      status = "Active"
+    }
     policy_entitlement = {
       target_category = "Cloud console"
       location_type   = "AWS"
-      policy_type     = "Recurring"
     }
-    time_zone = "UTC"
+    time_zone = var.time_zone
   }
-
-  delegation_classification = "Unrestricted"
 
   principals = [
     {
@@ -75,18 +75,19 @@ resource "idsec_policy_cloud_access" "audit" {
     }
   ]
 
-  targets = {
-    aws_account_targets = [
-      {
-        role_id      = var.audit_permission_set_arn
-        workspace_id = var.account_id
-      }
-    ]
-  }
-
   conditions = {
     max_session_duration = var.max_session_duration
     access_window        = local.access_window
+  }
+
+  targets = {
+    aws_organization_targets = [
+      {
+        role_id      = var.audit_permission_set_arn
+        workspace_id = var.account_id
+        org_id       = var.org_management_account_id
+      }
+    ]
   }
 }
 
@@ -94,15 +95,15 @@ resource "idsec_policy_cloud_access" "cloudops" {
   metadata = {
     name        = "aws-${var.account_name}-cloudops"
     description = "Cloud ops admin access to ${var.account_name} (${var.account_id})"
+    status = {
+      status = "Active"
+    }
     policy_entitlement = {
       target_category = "Cloud console"
       location_type   = "AWS"
-      policy_type     = "Recurring"
     }
-    time_zone = "UTC"
+    time_zone = var.time_zone
   }
-
-  delegation_classification = "Unrestricted"
 
   principals = [
     {
@@ -111,17 +112,18 @@ resource "idsec_policy_cloud_access" "cloudops" {
     }
   ]
 
-  targets = {
-    aws_account_targets = [
-      {
-        role_id      = var.cloudops_permission_set_arn
-        workspace_id = var.account_id
-      }
-    ]
-  }
-
   conditions = {
     max_session_duration = var.max_session_duration
     access_window        = local.access_window
+  }
+
+  targets = {
+    aws_organization_targets = [
+      {
+        role_id      = var.cloudops_permission_set_arn
+        workspace_id = var.account_id
+        org_id       = var.org_management_account_id
+      }
+    ]
   }
 }

--- a/modules/cyberark-policy/variables.tf
+++ b/modules/cyberark-policy/variables.tf
@@ -1,5 +1,5 @@
 variable "account_id" {
-  description = "12-digit AWS account ID"
+  description = "12-digit AWS account ID (workspace_id)"
   type        = string
 }
 
@@ -8,8 +8,13 @@ variable "account_name" {
   type        = string
 }
 
+variable "org_management_account_id" {
+  description = "AWS Organizations management account ID (used as org_id in policy targets)"
+  type        = string
+}
+
 variable "power_user_group_name" {
-  description = "CyberArk group name for power user access (replaces per-user principal)"
+  description = "CyberArk group name for power user access"
   type        = string
 }
 
@@ -42,4 +47,22 @@ variable "max_session_duration" {
   description = "Maximum session duration in hours"
   type        = number
   default     = 1
+}
+
+variable "time_zone" {
+  description = "IANA timezone name (e.g. America/New_York, Etc/UTC)"
+  type        = string
+  default     = "Etc/UTC"
+}
+
+variable "access_window_from_hour" {
+  description = "Access window start time, HH:MM:SS"
+  type        = string
+  default     = "08:00:00"
+}
+
+variable "access_window_to_hour" {
+  description = "Access window end time, HH:MM:SS"
+  type        = string
+  default     = "18:00:00"
 }

--- a/use-cases/cyberark-sca-policy/main.tf
+++ b/use-cases/cyberark-sca-policy/main.tf
@@ -21,6 +21,7 @@ module "cyberark_policy" {
 
   account_id                    = var.account_id
   account_name                  = var.account_name
+  org_management_account_id     = var.org_management_account_id
   power_user_group_name         = var.power_user_group_name
   power_user_permission_set_arn = var.power_user_permission_set_arn
   audit_permission_set_arn      = var.audit_permission_set_arn

--- a/use-cases/cyberark-sca-policy/variables.tf
+++ b/use-cases/cyberark-sca-policy/variables.tf
@@ -25,6 +25,11 @@ variable "account_name" {
   type        = string
 }
 
+variable "org_management_account_id" {
+  description = "AWS Organizations management account ID (used as org_id in policy targets)"
+  type        = string
+}
+
 variable "power_user_group_name" {
   description = "CyberArk group name for power user access"
   type        = string


### PR DESCRIPTION
The provider's documented schema diverges from what the SCA API actually accepts — five fields had to change to stop the generic 500 'Server got itself in trouble' response:

- metadata.status = { status = "Active" } is now required
- policy_entitlement.policy_type must be omitted (was "Recurring")
- time_zone must be IANA name (Etc/UTC), not "UTC" or "GMT"
- access_window.from_hour/to_hour are HH:MM:SS, not ISO 8601 datetimes
- targets uses aws_organization_targets with org_id (mgmt account), not aws_account_targets

Wires the AWS management account ID through as a new org_management_account_id var, fed by AWS_MANAGEMENT_ACCOUNT_ID secret. Reverts the TF_LOG debug capture now that the root cause is known. Rewrites the schema notes in CLAUDE.md to reflect the verified working payload from a CyberArk SE example.

https://claude.ai/code/session_01QXyhDgLFMRLTkMPN8n4kFj