### PR TITLE
fix: drop spaces from policy descriptions

### DIFF
--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -20,7 +20,7 @@ locals {
 resource "idsec_policy_cloud_access" "power_user" {
   metadata = {
     name        = "aws-${var.account_name}-poweruser"
-    description = "Power user access to ${var.account_name} [${var.account_id}]"
+    description = "PowerUser-access-${var.account_name}-${var.account_id}"
     status = {
       status = "Active"
     }
@@ -57,7 +57,7 @@ resource "idsec_policy_cloud_access" "power_user" {
 resource "idsec_policy_cloud_access" "audit" {
   metadata = {
     name        = "aws-${var.account_name}-audit"
-    description = "Read-only audit access to ${var.account_name} [${var.account_id}]"
+    description = "Audit-readonly-access-${var.account_name}-${var.account_id}"
     status = {
       status = "Active"
     }
@@ -94,7 +94,7 @@ resource "idsec_policy_cloud_access" "audit" {
 resource "idsec_policy_cloud_access" "cloudops" {
   metadata = {
     name        = "aws-${var.account_name}-cloudops"
-    description = "Cloud ops admin access to ${var.account_name} [${var.account_id}]"
+    description = "CloudOps-admin-access-${var.account_name}-${var.account_id}"
     status = {
       status = "Active"
     }


### PR DESCRIPTION
The SCA P1022 validator's allowlist message lists special characters but does not include space. Removing spaces from descriptions in favor of hyphens, which are explicitly allowed.

https://claude.ai/code/session_01QXyhDgLFMRLTkMPN8n4kFj