### PR TITLE
fix: serialize SCA policy creation with -parallelism=1

### DIFF
--- a/.github/workflows/aws-account-vending.yml
+++ b/.github/workflows/aws-account-vending.yml
@@ -361,7 +361,7 @@ jobs:
           TF_VAR_cloudops_role_name: ${{ secrets.CYBERARK_CLOUDOPS_ROLE }}
           TF_LOG: DEBUG
           TF_LOG_PATH: /tmp/tf-debug.log
-        run: terraform apply -auto-approve -no-color
+        run: terraform apply -auto-approve -no-color -parallelism=1
 
       - name: Surface SCA API error response (debug)
         if: failure()


### PR DESCRIPTION
The previous run got Audit through cleanly but PowerUser hit a transient 1101 'try again later' error and CloudOps landed in an 'Error' state — both pointing at a race in the SCA API when multiple policies target the same account workspace simultaneously.

Forcing terraform to apply one resource at a time eliminates the concurrency. Three sequential ~20s creations is acceptable for the demo workflow.

https://claude.ai/code/session_01QXyhDgLFMRLTkMPN8n4kFj