### PR TITLE
Add retry logic and pacing for SCA policy creation

### DIFF
--- a/.github/workflows/aws-account-vending.yml
+++ b/.github/workflows/aws-account-vending.yml
@@ -361,7 +361,23 @@ jobs:
           TF_VAR_cloudops_role_name: ${{ secrets.CYBERARK_CLOUDOPS_ROLE }}
           TF_LOG: DEBUG
           TF_LOG_PATH: /tmp/tf-debug.log
-        run: terraform apply -auto-approve -no-color -parallelism=1
+        run: |
+          # SCA backend is flaky when creating multiple policies for the same
+          # workspace. The module already paces creates with time_sleep, but a
+          # transient 1101 on the very first request can still fail the apply.
+          # Retry once after a 90s pause; terraform re-attempts only the
+          # failed/tainted resources.
+          attempt=1
+          max_attempts=2
+          until terraform apply -auto-approve -no-color -parallelism=1; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "❌ terraform apply failed after $attempt attempts"
+              exit 1
+            fi
+            echo "⚠️ terraform apply failed (attempt $attempt) — sleeping 90s before retry"
+            sleep 90
+            attempt=$((attempt + 1))
+          done
 
       - name: Surface SCA API error response (debug)
         if: failure()

--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "cyberark/idsec"
       version = ">= 0.1.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.0"
+    }
   }
 }
 
@@ -54,7 +58,14 @@ resource "idsec_policy_cloud_access" "power_user" {
   }
 }
 
+resource "time_sleep" "after_power_user" {
+  depends_on      = [idsec_policy_cloud_access.power_user]
+  create_duration = var.policy_create_delay
+}
+
 resource "idsec_policy_cloud_access" "audit" {
+  depends_on = [time_sleep.after_power_user]
+
   metadata = {
     name        = "aws-${var.account_name}-audit"
     description = "Audit-readonly-access-${var.account_name}-${var.account_id}"
@@ -91,7 +102,14 @@ resource "idsec_policy_cloud_access" "audit" {
   }
 }
 
+resource "time_sleep" "after_audit" {
+  depends_on      = [idsec_policy_cloud_access.audit]
+  create_duration = var.policy_create_delay
+}
+
 resource "idsec_policy_cloud_access" "cloudops" {
+  depends_on = [time_sleep.after_audit]
+
   metadata = {
     name        = "aws-${var.account_name}-cloudops"
     description = "CloudOps-admin-access-${var.account_name}-${var.account_id}"

--- a/modules/cyberark-policy/variables.tf
+++ b/modules/cyberark-policy/variables.tf
@@ -66,3 +66,9 @@ variable "access_window_to_hour" {
   type        = string
   default     = "18:00:00"
 }
+
+variable "policy_create_delay" {
+  description = "Wall-clock delay between SCA policy creates targeting the same workspace. Spaces out requests so the SCA backend doesn't 1101-rate-limit or land follow-up policies in 'Error' state."
+  type        = string
+  default     = "60s"
+}


### PR DESCRIPTION
## Summary
This PR improves the reliability of CyberArk SCA policy creation by adding retry logic to the Terraform apply step and introducing configurable delays between policy creates to prevent rate limiting and transient errors.

## Key Changes
- **Workflow retry logic**: Modified the `terraform apply` command in the AWS account vending workflow to retry once after a 90-second pause if the initial apply fails. This allows Terraform to re-attempt only failed/tainted resources rather than starting from scratch.
- **Policy creation pacing**: Added `time_sleep` resources between sequential policy creates (power_user → audit → cloudops) to space out requests to the SCA backend and prevent 1101 rate-limit errors.
- **Configurable delay**: Introduced a new `policy_create_delay` variable (default: 60s) to control the wall-clock delay between policy creates, making the pacing strategy adjustable without code changes.
- **Time provider dependency**: Added the Hashicorp `time` provider (>= 0.9.0) to the cyberark-policy module to support the sleep resources.

## Implementation Details
- The retry mechanism in the workflow includes informative logging (⚠️ and ❌ emojis) to indicate retry attempts and final failures.
- The `time_sleep` resources use `depends_on` to enforce sequential creation of policies while allowing Terraform to parallelize other operations.
- The solution addresses a known issue where the SCA backend can return transient 1101 errors even with existing module-level pacing, particularly on the first request.

https://claude.ai/code/session_01CWjG8nUThsA2C4AczJKfcb