### PR TITLE
fix SCA policy principal resolution and timezone default

### DIFF
--- a/modules/cyberark-policy/main.tf
+++ b/modules/cyberark-policy/main.tf
@@ -15,6 +15,13 @@ locals {
     from_hour        = var.access_window_from_hour
     to_hour          = var.access_window_to_hour
   }
+
+  # Strip wrapping single/double quotes and whitespace from role names —
+  # SCA matches principals by exact string, so `'ML-Cloud-Ops'` (literal
+  # quotes from a sloppily-stored secret) silently fails to resolve.
+  power_user_role_name = trim(trimspace(var.power_user_role_name), "'\"")
+  audit_role_name      = trim(trimspace(var.audit_role_name), "'\"")
+  cloudops_role_name   = trim(trimspace(var.cloudops_role_name), "'\"")
 }
 
 resource "idsec_policy_cloud_access" "power_user" {
@@ -33,7 +40,7 @@ resource "idsec_policy_cloud_access" "power_user" {
 
   principals = [
     {
-      name = var.power_user_role_name
+      name = local.power_user_role_name
       type = "ROLE"
     }
   ]
@@ -70,7 +77,7 @@ resource "idsec_policy_cloud_access" "audit" {
 
   principals = [
     {
-      name = var.audit_role_name
+      name = local.audit_role_name
       type = "ROLE"
     }
   ]
@@ -107,7 +114,7 @@ resource "idsec_policy_cloud_access" "cloudops" {
 
   principals = [
     {
-      name = var.cloudops_role_name
+      name = local.cloudops_role_name
       type = "ROLE"
     }
   ]

--- a/modules/cyberark-policy/variables.tf
+++ b/modules/cyberark-policy/variables.tf
@@ -52,7 +52,7 @@ variable "max_session_duration" {
 variable "time_zone" {
   description = "IANA timezone name (e.g. America/New_York, Etc/UTC)"
   type        = string
-  default     = "Etc/UTC"
+  default     = "America/New_York"
 }
 
 variable "access_window_from_hour" {


### PR DESCRIPTION
Two fixes after inspecting the created policy in the CyberArk Identity GUI:

- Principal name was rendered as literal `'ML-Cloud-Ops'` (with quotes) rather than `ML-Cloud-Ops`, so the role never resolved. The quotes came from the stored secret value. Defensively strip wrapping single/double quotes and whitespace in the module so a sloppily-stored secret can't silently break principal matching.

- time_zone default was `Etc/UTC`, which the SCA backend accepts but doesn't render as a usable zone in the GUI. Switch the default to `America/New_York` (Eastern) — IANA names are required.