### PR TITLE
Add error handling for Refresh Issue Templates workflow triggers

### DIFF
--- a/.github/workflows/aws-account-deprovision.yml
+++ b/.github/workflows/aws-account-deprovision.yml
@@ -242,6 +242,7 @@ jobs:
 
       - name: Trigger Refresh Issue Templates
         if: needs.deprovision-account.result == 'success'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aws-account-vending.yml
+++ b/.github/workflows/aws-account-vending.yml
@@ -8,6 +8,7 @@ permissions:
   issues: write
   contents: read
   id-token: write # Required for OIDC authentication with AWS
+  actions: write # Required to dispatch the Refresh Issue Templates workflow
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -403,6 +404,7 @@ jobs:
 
       - name: Trigger Refresh Issue Templates
         if: success()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR improves the resilience of the AWS account vending and deprovisioning workflows by adding error handling for the "Trigger Refresh Issue Templates" steps.

## Key Changes
- Added `actions: write` permission to the `aws-account-vending.yml` workflow to enable dispatching the Refresh Issue Templates workflow
- Added `continue-on-error: true` to the "Trigger Refresh Issue Templates" step in both `aws-account-vending.yml` and `aws-account-deprovision.yml` workflows

## Implementation Details
These changes ensure that if the Refresh Issue Templates workflow trigger fails, it will not cause the entire account vending or deprovisioning workflow to fail. This allows the primary workflow to complete successfully even if the secondary workflow dispatch encounters issues, improving overall workflow reliability and preventing cascading failures.

https://claude.ai/code/session_01UuQBZf5W6j8JQjDYzoSwaT